### PR TITLE
Some fixes

### DIFF
--- a/lib/ruby_technical_analysis/indicators/moving_averages.rb
+++ b/lib/ruby_technical_analysis/indicators/moving_averages.rb
@@ -59,8 +59,8 @@ module RubyTechnicalAnalysis
     def _ema_percentages
       @_ema_percentages ||=
         case period
-        when 12 then [0.846154, 0.153846]
-        when 26 then [0.925926, 0.074074]
+        when 12 then [0.153846, 0.846154]
+        when 26 then [0.074074, 0.925926]
         else
           last_obs_pct = 2.0 / (period + 1)
 

--- a/lib/ruby_technical_analysis/indicators/moving_averages.rb
+++ b/lib/ruby_technical_analysis/indicators/moving_averages.rb
@@ -30,7 +30,7 @@ module RubyTechnicalAnalysis
     def ema
       return series.last if period == 1
 
-      series.last(period).each_with_object([]) do |num, result|
+      series.each_with_object([]) do |num, result|
         result << if result.empty?
           num
         else

--- a/lib/ruby_technical_analysis/indicators/relative_strength_index.rb
+++ b/lib/ruby_technical_analysis/indicators/relative_strength_index.rb
@@ -30,7 +30,7 @@ module RubyTechnicalAnalysis
     private
 
     def _smooth_coef_one
-      @_smooth_coef_one ||= (1.0 / period).round(4)
+      @_smooth_coef_one ||= (1.0 / period)
     end
 
     def _smooth_coef_two
@@ -39,7 +39,7 @@ module RubyTechnicalAnalysis
 
     def calculate_channels(cla)
       period.times.map do |index|
-        diff = (cla.at(index) - cla.at(index + 1)).round(4)
+        diff = (cla.at(index) - cla.at(index + 1))
 
         [diff.negative? ? diff.abs : 0, diff.positive? ? diff : 0]
       end.transpose
@@ -53,8 +53,8 @@ module RubyTechnicalAnalysis
     end
 
     def calculate_subsequent_smoothing(up_ch, down_ch)
-      @smooth_up << (_smooth_coef_one * up_ch.last + _smooth_coef_two * @smooth_up.last).round(4)
-      @smooth_down << (_smooth_coef_one * down_ch.last + _smooth_coef_two * @smooth_down.last).round(4)
+      @smooth_up << (_smooth_coef_one * up_ch.last + _smooth_coef_two * @smooth_up.last)
+      @smooth_down << (_smooth_coef_one * down_ch.last + _smooth_coef_two * @smooth_down.last)
     end
 
     def calculate_smoothing(up_ch, down_ch)
@@ -67,7 +67,7 @@ module RubyTechnicalAnalysis
         up_ch, down_ch = calculate_channels(cla)
 
         calculate_smoothing(up_ch, down_ch)
-        @rsi << (100.00 - (100.00 / ((@smooth_up.last.to_f / @smooth_down.last) + 1))).round(4)
+        @rsi << (100.00 - (100.00 / ((@smooth_up.last.to_f / @smooth_down.last) + 1)))
       end.last
     end
   end


### PR DESCRIPTION
I added 3 fixes:

1. Removed the rounding in the RSI calculation so the number is more precise

2. Fixed the hardcoded percentages, they were swapped.

_Note: these numbers are the same as the calculation in case the period is not 12 or 26. I imagine these values are rounded and hardcoded for some specific use case. Maybe they can be removed and use the universal formula instead? 
(lines 65-67 of lib/ruby_technical_analysis/indicators/moving_averages.rb)_

3. Removed the data limitation of the EMA calculation, this allows the user to pass in a longer series than the EMA period and get a more precise EMA value.